### PR TITLE
[fix] ApiResponse 수정

### DIFF
--- a/spotify-web/src/main/java/com/example/spotifyweb/global/common/response/ApiResponse.java
+++ b/spotify-web/src/main/java/com/example/spotifyweb/global/common/response/ApiResponse.java
@@ -10,20 +10,21 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class ApiResponse<T> {
-    private HttpStatus status;
+    private int status;
     private String message;
     private T data;
 
-    public static <T> ApiResponse<T> success(HttpStatus status, String message, T data) {
+    public static <T> ApiResponse<T> success(int status, String message, T data) {
         return new ApiResponse<>(status, message, data);
     }
 
-    public static <T> ApiResponse<T> success(HttpStatus status, String message) {
+    public static <T> ApiResponse<T> success(int status, String message) {
         return new ApiResponse<>(status, message, null);
     }
 
-    public static <T> ApiResponse<T> error(HttpStatus status, String message) {
+    public static <T> ApiResponse<T> error(int status, String message) {
         return new ApiResponse<>(status, message, null);
     }
 }
+
 


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #3 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
ApiResponse 의 status 자료형을 변경해 주었습니다.

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
저는 아래와 같이 생각했습니다. 

ApiResponse의 status 자료형이 HttpStatus라면 다음과 같은 응답이 생성됩니다:
```json
{
  "status": "OK", 
  "message" : "성공",
}
```
"status"의 value 가 Http 상태코드의 정수 값이 아닌 문자열로 표현됩니다.
그렇기 때문에 API 명세서와 SuccessMessage 및 ErrorMessage 의 status 자료형도 HttpStatus 로 수정해야 합니다.


따라서 ApiResponse 의 status 자료형을 int 로 수정하는 작업이 기존 작업에서 수정해야 할 내용을 줄일 수 있다고 생각했습니다.

