### PR TITLE
[feat] 커스텀 예외클래스 생성 

### DIFF
--- a/spotify-web/src/main/java/com/example/spotifyweb/global/common/exception/BusinessException.java
+++ b/spotify-web/src/main/java/com/example/spotifyweb/global/common/exception/BusinessException.java
@@ -1,0 +1,14 @@
+package com.example.spotifyweb.global.common.exception;
+
+import com.example.spotifyweb.global.common.response.ErrorMessage;
+import lombok.Getter;
+@Getter
+public class BusinessException extends RuntimeException{
+    private ErrorMessage errorMessage;
+    public BusinessException(ErrorMessage errorMessage) {
+        super(errorMessage.getMessage());
+        this.errorMessage = errorMessage;
+    }
+
+}
+

--- a/spotify-web/src/main/java/com/example/spotifyweb/global/common/exception/GlobalExceptionHandler.java
+++ b/spotify-web/src/main/java/com/example/spotifyweb/global/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,19 @@
+package com.example.spotifyweb.global.common.exception;
+
+import com.example.spotifyweb.global.common.response.ApiResponse;
+import com.example.spotifyweb.global.common.response.ErrorMessage;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(NotFoundException.class)
+    protected ApiResponse handleNotFoundException(NotFoundException e) {
+        return ApiResponse.error(
+                ErrorMessage.STATION_NOT_FOUND_BY_ID_EXCEPTION.getStatus(),
+                ErrorMessage.STATION_NOT_FOUND_BY_ID_EXCEPTION.getMessage()
+        );
+    }
+
+}

--- a/spotify-web/src/main/java/com/example/spotifyweb/global/common/exception/NotFoundException.java
+++ b/spotify-web/src/main/java/com/example/spotifyweb/global/common/exception/NotFoundException.java
@@ -1,0 +1,8 @@
+package com.example.spotifyweb.global.common.exception;
+
+import com.example.spotifyweb.global.common.response.ErrorMessage;
+public class NotFoundException extends BusinessException {
+    public NotFoundException(ErrorMessage errorMessage) {
+        super(errorMessage);
+    }
+}

--- a/spotify-web/src/main/java/com/example/spotifyweb/global/common/response/ErrorMessage.java
+++ b/spotify-web/src/main/java/com/example/spotifyweb/global/common/response/ErrorMessage.java
@@ -2,12 +2,14 @@ package com.example.spotifyweb.global.common.response;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import org.springframework.http.HttpStatus;
 
 @Getter
 @AllArgsConstructor
 public enum ErrorMessage {
 
     //404
+    STATION_NOT_FOUND_BY_ID_EXCEPTION(HttpStatus.NOT_FOUND.value(), "ID에 해당하는 스테이션이 존재하지 않습니다."),
 
     //400
     ;


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #5 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
3차 세미나에서 배운 커스텀 예외 클래스를 생성했습니다.

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
저는 아래와 같이 생각했습니다.

스테이션에 따른 노래목록 조회 API 의 실패 응답은 아래와 같습니다.
```json
{
    "status": 400,
    "message": "ID에 해당하는 스테이션이 존재하지 않습니다."
    "data": null
}
```
스테이션 좋아요 API와 스테이션 좋아요 취소 API와 같이, 유효하지 않은 stationId에 대한 실패 응답이 유사한 모양이라는 것을 확인했습니다. 비슷한 예외 상황에 대해 반복되는 예외 처리 코드를 중복해서 작성하는 것을 커스텀 예외 클래스를 통해 방지할 수 있을 거라고 생각합니다. 







