### PR TITLE
[feat] 스테이션에 따른 노래 목록 조회 API 생성

### DIFF
--- a/spotify-web/src/main/java/com/example/spotifyweb/global/common/exception/GlobalExceptionHandler.java
+++ b/spotify-web/src/main/java/com/example/spotifyweb/global/common/exception/GlobalExceptionHandler.java
@@ -2,12 +2,15 @@ package com.example.spotifyweb.global.common.exception;
 
 import com.example.spotifyweb.global.common.response.ApiResponse;
 import com.example.spotifyweb.global.common.response.ErrorMessage;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ExceptionHandler(NotFoundException.class)
     protected ApiResponse handleNotFoundException(NotFoundException e) {
         return ApiResponse.error(

--- a/spotify-web/src/main/java/com/example/spotifyweb/global/common/response/ErrorMessage.java
+++ b/spotify-web/src/main/java/com/example/spotifyweb/global/common/response/ErrorMessage.java
@@ -9,9 +9,10 @@ import org.springframework.http.HttpStatus;
 public enum ErrorMessage {
 
     //404
-    STATION_NOT_FOUND_BY_ID_EXCEPTION(HttpStatus.NOT_FOUND.value(), "ID에 해당하는 스테이션이 존재하지 않습니다."),
 
     //400
+    STATION_NOT_FOUND_BY_ID_EXCEPTION(HttpStatus.BAD_REQUEST.value(), "ID에 해당하는 스테이션이 존재하지 않습니다."),
+
     ;
 
     private final int status;

--- a/spotify-web/src/main/java/com/example/spotifyweb/music/dto/MusicGetResponseDto.java
+++ b/spotify-web/src/main/java/com/example/spotifyweb/music/dto/MusicGetResponseDto.java
@@ -1,0 +1,10 @@
+package com.example.spotifyweb.music.dto;
+
+import com.example.spotifyweb.music.domain.Music;
+
+public record MusicGetResponseDto(Long musicId, String musicTitle, String singer) {
+    public static MusicGetResponseDto of (Music music){
+
+        return new MusicGetResponseDto(music.getId(), music.getMusicTitle(), music.getSinger());
+    }
+}

--- a/spotify-web/src/main/java/com/example/spotifyweb/stationMusic/StationMusicController.java
+++ b/spotify-web/src/main/java/com/example/spotifyweb/stationMusic/StationMusicController.java
@@ -1,0 +1,23 @@
+package com.example.spotifyweb.stationMusic;
+
+import com.example.spotifyweb.global.common.response.ApiResponse;
+import com.example.spotifyweb.global.common.response.SuccessMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class StationMusicController {
+
+    private final StationMusicService stationMusicService;
+
+    @GetMapping("/api/v1/{stationId}/musics")
+    public ApiResponse getMusics(@RequestHeader Long memberId, @PathVariable Long stationId, @RequestParam Long cursor) {
+
+        return ApiResponse.success(SuccessMessage.GET_MUSICS_SUCCESS.getStatus(), SuccessMessage.GET_MUSICS_SUCCESS.getMessage(), stationMusicService.getMusicByStationIdWithCursor(stationId, cursor));
+    }
+}

--- a/spotify-web/src/main/java/com/example/spotifyweb/stationMusic/StationMusicRepository.java
+++ b/spotify-web/src/main/java/com/example/spotifyweb/stationMusic/StationMusicRepository.java
@@ -1,0 +1,10 @@
+package com.example.spotifyweb.stationMusic;
+
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StationMusicRepository extends JpaRepository<StationMusic, Long> {
+
+    List<StationMusic> findFirst5ByStationIdOrderByIdAsc(Long stationId);
+    List<StationMusic> findTop5ByStationIdAndIdGreaterThanOrderByIdAsc(Long stationId, Long cursor);
+}

--- a/spotify-web/src/main/java/com/example/spotifyweb/stationMusic/StationMusicService.java
+++ b/spotify-web/src/main/java/com/example/spotifyweb/stationMusic/StationMusicService.java
@@ -1,0 +1,39 @@
+package com.example.spotifyweb.stationMusic;
+
+import com.example.spotifyweb.global.common.exception.NotFoundException;
+import com.example.spotifyweb.global.common.response.ErrorMessage;
+import com.example.spotifyweb.music.dto.MusicGetResponseDto;
+import com.example.spotifyweb.station.repository.StationsRepository;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class StationMusicService {
+
+    private final StationMusicRepository stationMusicRepository;
+
+    private final StationsRepository stationsRepository;
+
+    public List<MusicGetResponseDto> getMusicByStationIdWithCursor(Long stationId, Long cursor) {
+
+        // 존재하지 않는 stationId 이면 NotFoundException
+        stationsRepository.findById(stationId).orElseThrow(
+                () -> new NotFoundException(ErrorMessage.STATION_NOT_FOUND_BY_ID_EXCEPTION)
+        );
+
+        List<StationMusic> stationMusics;
+
+        if (cursor == -1) {
+            // cursor 값이 -1인 경우 특정 stationId에 해당하는 StationMusic을 PK기준으로 오름차순 정렬하고, 처음 5개의 결과를 반환합니다.
+            stationMusics = stationMusicRepository.findFirst5ByStationIdOrderByIdAsc(stationId);
+        } else {
+            // 특정 stationId에 해당하는 StationMusic을 PK기준으로 오름차순 정렬하고, PK > cursor 인 최대 5개의 결과를 반환합니다.
+            stationMusics = stationMusicRepository.findTop5ByStationIdAndIdGreaterThanOrderByIdAsc(stationId, cursor);
+        }
+
+        return stationMusics.stream().map(stationMusic -> MusicGetResponseDto.of(stationMusic.getMusic())).collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #9 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
스테이션에 따른 노래 목록 조회 API 을 생성했습니다.

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
JPA 에서 지원하는  "Query Creation" 기능을 사용해봤습니다. [Query Creation](https://docs.spring.io/spring-data/jpa/reference/jpa/query-methods.html)
```java
public interface StationMusicRepository extends JpaRepository<StationMusic, Long> {
    List<StationMusic> findFirst5ByStationIdOrderByIdAsc(Long stationId);
    List<StationMusic> findTop5ByStationIdAndIdGreaterThanOrderByIdAsc(Long stationId, Long cursor);
}
```
**findFirst5ByStationIdOrderByIdAsc(Long stationId)**
1. stationId 인 StationMusic 조회
2. PK 기준으로 오름차순 정렬
3. 처음 5개의 StationMusic을 return 

**findTop5ByStationIdAndIdGreaterThanOrderByIdAsc(Long stationId, Long cursor)**
1. stationId 인 StationMusic 조회
2. PK 기준으로 오름차순 정렬
3. PK > cursor인 최대 5개의 StationMusic을 return


_코드를 검토해주시고 피드백이 있으시면 언제든지 알려주시면 감사하겠습니다._


## 📬 Postman

<!-- postman 스크린샷을 첨부해주세요 -->
![image](https://github.com/NOW-SOPT-CDSP-8/Spotify-BE/assets/107605573/e699173f-12c1-4999-a1d4-e3995daaff20)
### **cursor 가 -1인 경우 (Music 5개를 가져옴)**
![image](https://github.com/NOW-SOPT-CDSP-8/Spotify-BE/assets/107605573/c6041f27-8a0a-4747-99fc-6a79535f57df)
### **stationId가 1인 음악 데이터를 5개의 더미로 채웠습니다. 현재 커서(cursor) 값은 3이므로, 4번째와 5번째 음악을 응답으로 받을 수 있습니다.** 
![image](https://github.com/NOW-SOPT-CDSP-8/Spotify-BE/assets/107605573/37a6d72c-5a74-4a0a-829c-e93f1edd1c8c)
### **존재하지 않는 stationId 일 경우입니다.**


