### PR TITLE
[feat] 스테이션 좋아요 api 구현

### DIFF
--- a/spotify-web/src/main/java/com/example/spotifyweb/global/common/exception/GlobalExceptionHandler.java
+++ b/spotify-web/src/main/java/com/example/spotifyweb/global/common/exception/GlobalExceptionHandler.java
@@ -1,7 +1,6 @@
 package com.example.spotifyweb.global.common.exception;
 
 import com.example.spotifyweb.global.common.response.ApiResponse;
-import com.example.spotifyweb.global.common.response.ErrorMessage;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -14,9 +13,8 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(NotFoundException.class)
     protected ApiResponse handleNotFoundException(NotFoundException e) {
         return ApiResponse.error(
-                ErrorMessage.STATION_NOT_FOUND_BY_ID_EXCEPTION.getStatus(),
-                ErrorMessage.STATION_NOT_FOUND_BY_ID_EXCEPTION.getMessage()
+                e.getErrorMessage().getStatus(),
+                e.getErrorMessage().getMessage()
         );
     }
-
 }

--- a/spotify-web/src/main/java/com/example/spotifyweb/global/common/response/ErrorMessage.java
+++ b/spotify-web/src/main/java/com/example/spotifyweb/global/common/response/ErrorMessage.java
@@ -12,8 +12,8 @@ public enum ErrorMessage {
 
     //400
     STATION_NOT_FOUND_BY_ID_EXCEPTION(HttpStatus.BAD_REQUEST.value(), "ID에 해당하는 스테이션이 존재하지 않습니다."),
-
-    ;
+    MEMBER_NOT_FOUND_BY_ID_EXCEPTION(HttpStatus.BAD_REQUEST.value(), "ID에 해당하는 멤버가 존재하지 않습니다."),
+    DUPLICATION_STATION_LIKE(HttpStatus.BAD_REQUEST.value(), "해당하는 회원이 이미 좋아요를 한 스테이션입니다.");
 
     private final int status;
     private final String message;

--- a/spotify-web/src/main/java/com/example/spotifyweb/global/common/response/ErrorMessage.java
+++ b/spotify-web/src/main/java/com/example/spotifyweb/global/common/response/ErrorMessage.java
@@ -9,10 +9,10 @@ import org.springframework.http.HttpStatus;
 public enum ErrorMessage {
 
     //404
+    STATION_NOT_FOUND_BY_ID_EXCEPTION(HttpStatus.NOT_FOUND.value(), "ID에 해당하는 스테이션이 존재하지 않습니다."),
+    MEMBER_NOT_FOUND_BY_ID_EXCEPTION(HttpStatus.NOT_FOUND.value(), "ID에 해당하는 멤버가 존재하지 않습니다."),
 
     //400
-    STATION_NOT_FOUND_BY_ID_EXCEPTION(HttpStatus.BAD_REQUEST.value(), "ID에 해당하는 스테이션이 존재하지 않습니다."),
-    MEMBER_NOT_FOUND_BY_ID_EXCEPTION(HttpStatus.BAD_REQUEST.value(), "ID에 해당하는 멤버가 존재하지 않습니다."),
     DUPLICATION_STATION_LIKE(HttpStatus.BAD_REQUEST.value(), "해당하는 회원이 이미 좋아요를 한 스테이션입니다.");
 
     private final int status;

--- a/spotify-web/src/main/java/com/example/spotifyweb/global/common/response/SuccessMessage.java
+++ b/spotify-web/src/main/java/com/example/spotifyweb/global/common/response/SuccessMessage.java
@@ -9,10 +9,12 @@ import org.springframework.http.HttpStatus;
 public enum SuccessMessage {
 
     //200
-    GET_STATIONS_SUCCESS(HttpStatus.OK.value(),"스테이션 제목 조회 성공"),
-    GET_MUSICS_SUCCESS(HttpStatus.OK.value(), "스테이션에 따른 노래 리스트 조회 성공");
-    //202
+    GET_STATIONS_SUCCESS(HttpStatus.OK.value(), "스테이션 제목 조회 성공"),
+    GET_MUSICS_SUCCESS(HttpStatus.OK.value(), "스테이션에 따른 노래 리스트 조회 성공"),
+    POST_STATION_LIKING_SUCCESS(HttpStatus.OK.value(), "스테이션 좋아요 성공")
 
+    //202
+    ;
     private final int status;
     private final String message;
 }

--- a/spotify-web/src/main/java/com/example/spotifyweb/global/common/response/SuccessMessage.java
+++ b/spotify-web/src/main/java/com/example/spotifyweb/global/common/response/SuccessMessage.java
@@ -11,7 +11,9 @@ public enum SuccessMessage {
     //200
     GET_STATIONS_SUCCESS(HttpStatus.OK.value(), "스테이션 제목 조회 성공"),
     GET_MUSICS_SUCCESS(HttpStatus.OK.value(), "스테이션에 따른 노래 리스트 조회 성공"),
-    POST_STATION_LIKING_SUCCESS(HttpStatus.OK.value(), "스테이션 좋아요 성공")
+
+    //201
+    POST_STATION_LIKING_SUCCESS(HttpStatus.CREATED.value(), "스테이션 좋아요 성공")
 
     //202
     ;

--- a/spotify-web/src/main/java/com/example/spotifyweb/member/repository/MemberRepository.java
+++ b/spotify-web/src/main/java/com/example/spotifyweb/member/repository/MemberRepository.java
@@ -1,0 +1,14 @@
+package com.example.spotifyweb.member.repository;
+
+import com.example.spotifyweb.global.common.exception.NotFoundException;
+import com.example.spotifyweb.global.common.response.ErrorMessage;
+import com.example.spotifyweb.member.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    default Member findByIdOrThrow(Long memberId) throws NotFoundException {
+        return findById(memberId).orElseThrow(
+                () -> new NotFoundException(ErrorMessage.MEMBER_NOT_FOUND_BY_ID_EXCEPTION));
+    }
+}

--- a/spotify-web/src/main/java/com/example/spotifyweb/station/controller/StationController.java
+++ b/spotify-web/src/main/java/com/example/spotifyweb/station/controller/StationController.java
@@ -5,18 +5,29 @@ import com.example.spotifyweb.global.common.response.SuccessMessage;
 import com.example.spotifyweb.station.service.StationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-public class StationController{
+public class StationController {
 
     private final StationService stationService;
 
     @GetMapping("/api/v1/stations")
     public ApiResponse getStations(@RequestHeader(value = "memberId") Long memberId) {
 
-        return ApiResponse.success(SuccessMessage.GET_STATIONS_SUCCESS.getStatus(), SuccessMessage.GET_STATIONS_SUCCESS.getMessage(), stationService.getStations());
+        return ApiResponse.success(SuccessMessage.GET_STATIONS_SUCCESS.getStatus(),
+                SuccessMessage.GET_STATIONS_SUCCESS.getMessage(), stationService.getStations());
+    }
+
+    @PostMapping("/api/v1/{staionId}/liked")
+    public ApiResponse postStation(@RequestHeader(value = "memberId") Long memberId,
+                                   @PathVariable("staionId") Long staionId) {
+
+        return ApiResponse.success(SuccessMessage.POST_STATION_LIKING_SUCCESS.getStatus(),
+                SuccessMessage.POST_STATION_LIKING_SUCCESS.getMessage());
     }
 }

--- a/spotify-web/src/main/java/com/example/spotifyweb/station/controller/StationController.java
+++ b/spotify-web/src/main/java/com/example/spotifyweb/station/controller/StationController.java
@@ -26,7 +26,7 @@ public class StationController {
     @PostMapping("/api/v1/{staionId}/liked")
     public ApiResponse postStation(@RequestHeader(value = "memberId") Long memberId,
                                    @PathVariable("staionId") Long staionId) {
-
+        stationService.postStationLiking(memberId, staionId);
         return ApiResponse.success(SuccessMessage.POST_STATION_LIKING_SUCCESS.getStatus(),
                 SuccessMessage.POST_STATION_LIKING_SUCCESS.getMessage());
     }

--- a/spotify-web/src/main/java/com/example/spotifyweb/station/domain/StationLiking.java
+++ b/spotify-web/src/main/java/com/example/spotifyweb/station/domain/StationLiking.java
@@ -22,8 +22,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-@Builder(access = AccessLevel.PRIVATE)
-public class StationLikings extends BaseTimeEntity {
+public class StationLiking extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -37,5 +36,11 @@ public class StationLikings extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "\"memberId\"")
     private Member member;
+
+    @Builder
+    public StationLiking(Station station, Member member) {
+        this.station = station;
+        this.member = member;
+    }
 
 }

--- a/spotify-web/src/main/java/com/example/spotifyweb/station/domain/StationLikings.java
+++ b/spotify-web/src/main/java/com/example/spotifyweb/station/domain/StationLikings.java
@@ -1,8 +1,7 @@
-package com.example.spotifyweb.stationLikings.domain;
+package com.example.spotifyweb.station.domain;
 
 import com.example.spotifyweb.global.common.entitiy.BaseTimeEntity;
 import com.example.spotifyweb.member.domain.Member;
-import com.example.spotifyweb.station.domain.Station;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;

--- a/spotify-web/src/main/java/com/example/spotifyweb/station/repository/StationLikingRepository.java
+++ b/spotify-web/src/main/java/com/example/spotifyweb/station/repository/StationLikingRepository.java
@@ -1,0 +1,10 @@
+package com.example.spotifyweb.station.repository;
+
+import com.example.spotifyweb.member.domain.Member;
+import com.example.spotifyweb.station.domain.Station;
+import com.example.spotifyweb.station.domain.StationLiking;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StationLikingRepository extends JpaRepository<StationLiking, Long> {
+    Boolean existsByMemberAndStation(Member member, Station station);
+}

--- a/spotify-web/src/main/java/com/example/spotifyweb/station/repository/StationRepository.java
+++ b/spotify-web/src/main/java/com/example/spotifyweb/station/repository/StationRepository.java
@@ -1,0 +1,14 @@
+package com.example.spotifyweb.station.repository;
+
+import com.example.spotifyweb.global.common.exception.NotFoundException;
+import com.example.spotifyweb.global.common.response.ErrorMessage;
+import com.example.spotifyweb.station.domain.Station;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StationRepository extends JpaRepository<Station, Long> {
+
+    default Station findByIdOrThrow(Long stationId) throws NotFoundException {
+        return findById(stationId).orElseThrow(
+                () -> new NotFoundException(ErrorMessage.STATION_NOT_FOUND_BY_ID_EXCEPTION));
+    }
+}

--- a/spotify-web/src/main/java/com/example/spotifyweb/station/repository/StationsRepository.java
+++ b/spotify-web/src/main/java/com/example/spotifyweb/station/repository/StationsRepository.java
@@ -1,7 +1,0 @@
-package com.example.spotifyweb.station.repository;
-
-import com.example.spotifyweb.station.domain.Station;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface StationsRepository extends JpaRepository<Station, Long> {
-}

--- a/spotify-web/src/main/java/com/example/spotifyweb/station/service/StationService.java
+++ b/spotify-web/src/main/java/com/example/spotifyweb/station/service/StationService.java
@@ -1,20 +1,50 @@
 package com.example.spotifyweb.station.service;
 
+import com.example.spotifyweb.global.common.exception.NotFoundException;
+import com.example.spotifyweb.global.common.response.ErrorMessage;
+import com.example.spotifyweb.member.domain.Member;
+import com.example.spotifyweb.member.repository.MemberRepository;
 import com.example.spotifyweb.station.domain.Station;
+import com.example.spotifyweb.station.domain.StationLiking;
 import com.example.spotifyweb.station.dto.StationGetResponseDto;
-import com.example.spotifyweb.station.repository.StationsRepository;
+import com.example.spotifyweb.station.repository.StationLikingRepository;
+import com.example.spotifyweb.station.repository.StationRepository;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
 @Service
 @RequiredArgsConstructor
-public class StationService{
+public class StationService {
 
-    private final StationsRepository stationsRepository;
-    public List<StationGetResponseDto> getStations(){
+    private final StationRepository stationsRepository;
+    private final MemberRepository memberRepository;
+    private final StationLikingRepository stationLikingRepository;
+
+    public List<StationGetResponseDto> getStations() {
 
         List<Station> stations = stationsRepository.findAll();
         return stations.stream().map(StationGetResponseDto::of).collect(Collectors.toList());
+    }
+
+    public void postStationLiking(Long memberId, Long stationId) {
+
+        Station station = stationsRepository.findByIdOrThrow(stationId);
+        Member member = memberRepository.findByIdOrThrow(memberId);
+
+        StationLiking stationLiking = StationLiking.builder()
+                .station(station)
+                .member(member)
+                .build();
+
+        isDuplicateStationLiking(member, station);
+        stationLikingRepository.save(stationLiking);
+    }
+
+    private void isDuplicateStationLiking(Member member, Station station) {
+        if (stationLikingRepository.existsByMemberAndStation(member, station)) {
+            throw new NotFoundException(ErrorMessage.DUPLICATION_STATION_LIKE);
+        }
     }
 }

--- a/spotify-web/src/main/java/com/example/spotifyweb/stationMusic/StationMusicService.java
+++ b/spotify-web/src/main/java/com/example/spotifyweb/stationMusic/StationMusicService.java
@@ -3,7 +3,7 @@ package com.example.spotifyweb.stationMusic;
 import com.example.spotifyweb.global.common.exception.NotFoundException;
 import com.example.spotifyweb.global.common.response.ErrorMessage;
 import com.example.spotifyweb.music.dto.MusicGetResponseDto;
-import com.example.spotifyweb.station.repository.StationsRepository;
+import com.example.spotifyweb.station.repository.StationRepository;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -15,7 +15,7 @@ public class StationMusicService {
 
     private final StationMusicRepository stationMusicRepository;
 
-    private final StationsRepository stationsRepository;
+    private final StationRepository stationsRepository;
 
     public List<MusicGetResponseDto> getMusicByStationIdWithCursor(Long stationId, Long cursor) {
 
@@ -34,6 +34,7 @@ public class StationMusicService {
             stationMusics = stationMusicRepository.findTop5ByStationIdAndIdGreaterThanOrderByIdAsc(stationId, cursor);
         }
 
-        return stationMusics.stream().map(stationMusic -> MusicGetResponseDto.of(stationMusic.getMusic())).collect(Collectors.toList());
+        return stationMusics.stream().map(stationMusic -> MusicGetResponseDto.of(stationMusic.getMusic()))
+                .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #11 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
스테이션 좋아요 api를 구현했습니다. 해당하는 회원이 이미 좋아요를 누를 경우 badRequest를 발생시키는 예외처리를 진행했습니다.

작은 에러들(클래스명수정, GlobalExceptionHandler)등 처리했습니다. 

수정 전 GlobalExceptionHandler의 경우 모든 badRequest를 stationNotFound로 처리하길래 멤버id가 잘못되거나하는 다양한 경우가 존재한다고 생각하여 수정해줬습니다.

예외상황에서 postman과 response의 응답코드가 상이한 부분을 전에 말씀드렸었는데 @ResponseStatus(HttpStatus.BAD_REQUEST)를 사용하면 404든 400이든 다 400으로 postman에서 처리하게 됩니다. 이거 실제 응답코드로 매칭하는게 있었는데.. 우선 구현 후 리팩토링으로 가져가겠습니다!

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
커밋 날릴 때 깃모지를 잘 안붙였네요..다음부턴 잘하겠습니다~
그리고 우테코 포맷 적용 안되어 계신거같아요 ! 확인부탁드려요
그리고 notFound는 404입니다! 에러코드도 한번 알아보시면 좋을 것 같습니다.
## 📬 Postman
<!-- postman 스크린샷을 첨부해주세요 -->
- 존재하지 않는 회원 예외처리
<img width="521" alt="image" src="https://github.com/NOW-SOPT-CDSP-8/Spotify-BE/assets/128011308/0b592ce3-2144-438a-b29f-5da0d9f0718c">

- 존재하지 않는 스테이션 예외처리
<img width="529" alt="image" src="https://github.com/NOW-SOPT-CDSP-8/Spotify-BE/assets/128011308/65fc9444-de16-4877-99c0-3348a2a6c22e">

-성공요청
<img width="528" alt="image" src="https://github.com/NOW-SOPT-CDSP-8/Spotify-BE/assets/128011308/43da2ce3-e9fe-44a6-8e61-7769560b14d2">

