### PR TITLE
[feat] 멤버 프로필 조회 API 생성 #14

### DIFF
--- a/spotify-web/src/main/java/com/example/spotifyweb/api/card/dto/CardGetResponsedDto.java
+++ b/spotify-web/src/main/java/com/example/spotifyweb/api/card/dto/CardGetResponsedDto.java
@@ -1,0 +1,10 @@
+package com.example.spotifyweb.api.card.dto;
+
+import com.example.spotifyweb.api.card.domain.Card;
+import com.example.spotifyweb.api.card.domain.CardCategory;
+
+public record CardGetResponsedDto(String cardName, CardCategory cardType, String cardNumber) {
+    public static CardGetResponsedDto of(Card card) {
+        return new CardGetResponsedDto(card.getCardName(), card.getCardType(), card.getCardNumber());
+    }
+}

--- a/spotify-web/src/main/java/com/example/spotifyweb/api/member/controller/MemberController.java
+++ b/spotify-web/src/main/java/com/example/spotifyweb/api/member/controller/MemberController.java
@@ -1,0 +1,23 @@
+package com.example.spotifyweb.api.member.controller;
+
+import com.example.spotifyweb.api.member.service.MemberService;
+import com.example.spotifyweb.global.common.response.ApiResponse;
+import com.example.spotifyweb.global.common.response.SuccessMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @GetMapping("/api/v1/profile")
+    public ApiResponse getProfile(@RequestHeader(value = "memberId") Long memberId) {
+
+        return ApiResponse.success(SuccessMessage.GET_PROFILE_SUCCESS.getStatus(),
+                SuccessMessage.GET_PROFILE_SUCCESS.getMessage(), memberService.getMemberProfile(memberId));
+    }
+}

--- a/spotify-web/src/main/java/com/example/spotifyweb/api/member/dto/ProfileGetResponsedDto.java
+++ b/spotify-web/src/main/java/com/example/spotifyweb/api/member/dto/ProfileGetResponsedDto.java
@@ -1,0 +1,11 @@
+package com.example.spotifyweb.api.member.dto;
+
+import com.example.spotifyweb.api.card.dto.CardGetResponsedDto;
+import com.example.spotifyweb.api.member.domain.Member;
+
+public record ProfileGetResponsedDto(String memberName, Boolean isSubscribe, CardGetResponsedDto card) {
+    public static ProfileGetResponsedDto of(Member member) {
+        return new ProfileGetResponsedDto(member.getMemberName(), member.isSubscribed(),
+                CardGetResponsedDto.of(member.getCard()));
+    }
+}

--- a/spotify-web/src/main/java/com/example/spotifyweb/api/member/service/MemberService.java
+++ b/spotify-web/src/main/java/com/example/spotifyweb/api/member/service/MemberService.java
@@ -1,0 +1,22 @@
+package com.example.spotifyweb.api.member.service;
+
+import com.example.spotifyweb.api.member.dto.ProfileGetResponsedDto;
+import com.example.spotifyweb.api.member.repository.MemberRepository;
+import com.example.spotifyweb.global.common.exception.NotFoundException;
+import com.example.spotifyweb.global.common.response.ErrorMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    public ProfileGetResponsedDto getMemberProfile(Long memberId) {
+
+        return ProfileGetResponsedDto.of(memberRepository.findById(memberId).orElseThrow(
+                () -> new NotFoundException(ErrorMessage.MEMBER_NOT_FOUND_BY_ID_EXCEPTION)
+        ));
+    }
+}

--- a/spotify-web/src/main/java/com/example/spotifyweb/global/common/response/SuccessMessage.java
+++ b/spotify-web/src/main/java/com/example/spotifyweb/global/common/response/SuccessMessage.java
@@ -12,7 +12,7 @@ public enum SuccessMessage {
     GET_STATIONS_SUCCESS(HttpStatus.OK.value(), "스테이션 제목 조회 성공"),
     GET_MUSICS_SUCCESS(HttpStatus.OK.value(), "스테이션에 따른 노래 리스트 조회 성공"),
     DELETE_STATION_LIKING_SUCCESS(HttpStatus.OK.value(), "스테이션 좋아요 취소 성공"),
-
+    GET_PROFILE_SUCCESS(HttpStatus.OK.value(), "프로필 조회 성공"),
     //201
     POST_STATION_LIKING_SUCCESS(HttpStatus.CREATED.value(), "스테이션 좋아요 성공")
 


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #14 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
멤버 프로필 조회 API를 만들었습니다.

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
멤버 프로필 조회API 의 성공응답은 아래와 같습니다.
```json
{
    "status": 200,
    "message": "프로필 조회 성공",
    "data": {
    "memberName" : "혁진",
    "isSubscribed" : true,
    "cardInfo" : {
	    "cardName" : "토스뱅크카드",
	    "cardType" : "체크",
	    "cardNumber" : "0455"
	    }
     }
}

```
한 응답 안에 회원과 카드의 정보가 모두 포함되어 있습니다. 이에 따라 CardGetResponseDto가 필요하다고 판단했습니다.




[ProfileGetResponsedDto](https://github.com/NOW-SOPT-CDSP-8/Spotify-BE/blob/20f9ba0f6765347c16175513ea958b4529fb8088/spotify-web/src/main/java/com/example/spotifyweb/api/member/dto/ProfileGetResponsedDto.java#L6C1-L11C2) 에서  [CardGetResponseDto](https://github.com/NOW-SOPT-CDSP-8/Spotify-BE/blob/20f9ba0f6765347c16175513ea958b4529fb8088/spotify-web/src/main/java/com/example/spotifyweb/api/card/dto/CardGetResponsedDto.java#L6C1-L10C1)를 이용해 응답을 생성합니다
하지만 이 방법이 최선인지 확신이 서지 않습니다. 더 좋은 의견이 있으시면 알려주시면 감사하겠습니다!


## 📬 Postman
<!-- postman 스크린샷을 첨부해주세요 -->
![image](https://github.com/NOW-SOPT-CDSP-8/Spotify-BE/assets/107605573/552aea9b-b47e-4c8a-bace-bfa3ba855f4c)


