### PR TITLE
[feat] 장르에 따른 음악 필터링 조회 API 구현

### DIFF
--- a/spotify-web/src/main/java/com/example/spotifyweb/api/filter/filterRepository/FilterRepository.java
+++ b/spotify-web/src/main/java/com/example/spotifyweb/api/filter/filterRepository/FilterRepository.java
@@ -1,0 +1,14 @@
+package com.example.spotifyweb.api.filter.filterRepository;
+
+import com.example.spotifyweb.api.filter.domain.Filter;
+import com.example.spotifyweb.global.common.exception.NotFoundException;
+import com.example.spotifyweb.global.common.response.ErrorMessage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FilterRepository extends JpaRepository<Filter, Long> {
+
+    default Filter findByIdOrThrow(Long filterId) throws NotFoundException {
+        return findById(filterId).orElseThrow(
+                () -> new NotFoundException(ErrorMessage.FILTER_NOT_FOUND_BY_ID_EXCEPTION));
+    }
+}

--- a/spotify-web/src/main/java/com/example/spotifyweb/api/music/GenreCategory.java
+++ b/spotify-web/src/main/java/com/example/spotifyweb/api/music/GenreCategory.java
@@ -1,5 +1,5 @@
 package com.example.spotifyweb.api.music;
 
 public enum GenreCategory {
-    팝, 힙합, 알앤비, 발라드, 댄스
+    pop, philipinepop, latinpop
 }

--- a/spotify-web/src/main/java/com/example/spotifyweb/api/music/controller/musicController.java
+++ b/spotify-web/src/main/java/com/example/spotifyweb/api/music/controller/musicController.java
@@ -1,0 +1,30 @@
+package com.example.spotifyweb.api.music.controller;
+
+import com.example.spotifyweb.api.music.domain.GenreCategory;
+import com.example.spotifyweb.api.music.service.MusicService;
+import com.example.spotifyweb.global.common.response.ApiResponse;
+import com.example.spotifyweb.global.common.response.SuccessMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/musics")
+public class musicController {
+
+    private final MusicService musicService;
+
+    @GetMapping("/filter/{filterId}")
+    public ApiResponse getMusics(@RequestHeader(value = "memberId") Long memberId,
+                                 @RequestParam(name = "genre") GenreCategory genre,
+                                 @PathVariable(name = "filterId") Long filterId) {
+        return ApiResponse.success(SuccessMessage.GET_MUSICS_BY_GENRE_AND_FILTER_SUCCESS.getStatus(),
+                SuccessMessage.GET_MUSICS_BY_GENRE_AND_FILTER_SUCCESS.getMessage(),
+                musicService.getMusicsByGenreAndFilter(genre, filterId));
+    }
+}

--- a/spotify-web/src/main/java/com/example/spotifyweb/api/music/domain/GenreCategory.java
+++ b/spotify-web/src/main/java/com/example/spotifyweb/api/music/domain/GenreCategory.java
@@ -1,4 +1,4 @@
-package com.example.spotifyweb.api.music;
+package com.example.spotifyweb.api.music.domain;
 
 public enum GenreCategory {
     pop, philipinepop, latinpop

--- a/spotify-web/src/main/java/com/example/spotifyweb/api/music/domain/Music.java
+++ b/spotify-web/src/main/java/com/example/spotifyweb/api/music/domain/Music.java
@@ -1,7 +1,6 @@
 package com.example.spotifyweb.api.music.domain;
 
 
-import com.example.spotifyweb.api.music.GenreCategory;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;

--- a/spotify-web/src/main/java/com/example/spotifyweb/api/music/dto/MusicInfo.java
+++ b/spotify-web/src/main/java/com/example/spotifyweb/api/music/dto/MusicInfo.java
@@ -1,0 +1,29 @@
+package com.example.spotifyweb.api.music.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.time.LocalDate;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+public class MusicInfo {
+
+    private final String musicTitle;
+    private final String singer;
+    private final Long musicLikings;
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private final LocalDate musicReleaseDate;
+
+    public static MusicInfo of(String musicTitle, String singer, long musicLikings, LocalDate musicReleaseDate) {
+        return MusicInfo.builder()
+                .musicTitle(musicTitle)
+                .singer(singer)
+                .musicLikings(musicLikings)
+                .musicReleaseDate(musicReleaseDate)
+                .build();
+    }
+}

--- a/spotify-web/src/main/java/com/example/spotifyweb/api/music/dto/MusicsGetResponseDto.java
+++ b/spotify-web/src/main/java/com/example/spotifyweb/api/music/dto/MusicsGetResponseDto.java
@@ -2,12 +2,8 @@ package com.example.spotifyweb.api.music.dto;
 
 import com.example.spotifyweb.api.playlist.dto.PlaylistInfo;
 import java.util.List;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
-public class MusicsGetResponseDto {
-    private final List<PlaylistInfo> playlists;
-    private final List<MusicInfo> musics;
+public record MusicsGetResponseDto(
+        List<PlaylistInfo> playlists,
+        List<MusicInfo> musics) {
 }

--- a/spotify-web/src/main/java/com/example/spotifyweb/api/music/dto/MusicsGetResponseDto.java
+++ b/spotify-web/src/main/java/com/example/spotifyweb/api/music/dto/MusicsGetResponseDto.java
@@ -1,0 +1,13 @@
+package com.example.spotifyweb.api.music.dto;
+
+import com.example.spotifyweb.api.playlist.dto.PlaylistInfo;
+import java.util.List;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class MusicsGetResponseDto {
+    private final List<PlaylistInfo> playlists;
+    private final List<MusicInfo> musics;
+}

--- a/spotify-web/src/main/java/com/example/spotifyweb/api/music/repository/MusicRepository.java
+++ b/spotify-web/src/main/java/com/example/spotifyweb/api/music/repository/MusicRepository.java
@@ -1,0 +1,14 @@
+package com.example.spotifyweb.api.music.repository;
+
+import com.example.spotifyweb.api.music.domain.GenreCategory;
+import com.example.spotifyweb.api.music.domain.Music;
+import java.time.LocalDate;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface MusicRepository extends JpaRepository<Music, Long> {
+
+    @Query("SELECT m FROM Music m WHERE m.genreTitle = :genre AND m.musicReleaseDate BETWEEN :startDate AND :endDate")
+    List<Music> findMusicsByGenreAndFilter(GenreCategory genre, LocalDate startDate, LocalDate endDate);
+}

--- a/spotify-web/src/main/java/com/example/spotifyweb/api/music/service/MusicService.java
+++ b/spotify-web/src/main/java/com/example/spotifyweb/api/music/service/MusicService.java
@@ -1,0 +1,47 @@
+package com.example.spotifyweb.api.music.service;
+
+import com.example.spotifyweb.api.filter.domain.Filter;
+import com.example.spotifyweb.api.filter.filterRepository.FilterRepository;
+import com.example.spotifyweb.api.music.domain.GenreCategory;
+import com.example.spotifyweb.api.music.domain.Music;
+import com.example.spotifyweb.api.music.dto.MusicInfo;
+import com.example.spotifyweb.api.music.dto.MusicsGetResponseDto;
+import com.example.spotifyweb.api.music.repository.MusicRepository;
+import com.example.spotifyweb.api.playlist.domain.Playlist;
+import com.example.spotifyweb.api.playlist.dto.PlaylistInfo;
+import com.example.spotifyweb.api.playlist.repository.PlaylistRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class MusicService {
+
+    private final PlaylistRepository playlistRepository;
+    private final MusicRepository musicRepository;
+    private final FilterRepository filterRepository;
+
+    public MusicsGetResponseDto getMusicsByGenreAndFilter(GenreCategory genre, Long filterId) {
+        List<Playlist> playlists = playlistRepository.findAll();
+
+        List<PlaylistInfo> playlistInfos = playlists.stream()
+                .map(PlaylistInfo::of)
+                .toList();
+
+        Filter filter = filterRepository.findByIdOrThrow(filterId);
+        List<Music> musics = musicRepository.findMusicsByGenreAndFilter(genre, filter.getStartDate(),
+                filter.getEndDate());
+
+        List<MusicInfo> musicInfos = musics.stream()
+                .map(oneMusic -> MusicInfo.of(oneMusic.getMusicTitle(),
+                        oneMusic.getSinger(),
+                        oneMusic.getMusicLikings(),
+                        oneMusic.getMusicReleaseDate()))
+                .toList();
+
+        return new MusicsGetResponseDto(playlistInfos, musicInfos);
+    }
+}

--- a/spotify-web/src/main/java/com/example/spotifyweb/api/playlist/domain/Playlist.java
+++ b/spotify-web/src/main/java/com/example/spotifyweb/api/playlist/domain/Playlist.java
@@ -1,0 +1,39 @@
+package com.example.spotifyweb.api.playlist.domain;
+
+import com.example.spotifyweb.global.common.entitiy.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Table(name = "playlists")
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class Playlist extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long playlistId;
+
+    @Column(length = 30, nullable = false)
+    private String playlistTitle;
+
+    @Column(nullable = false)
+    private int followers;
+
+    @Builder
+    public Playlist(String playlistTitle, int followers) {
+        this.playlistTitle = playlistTitle;
+        this.followers = followers;
+    }
+}
+

--- a/spotify-web/src/main/java/com/example/spotifyweb/api/playlist/dto/PlaylistInfo.java
+++ b/spotify-web/src/main/java/com/example/spotifyweb/api/playlist/dto/PlaylistInfo.java
@@ -1,0 +1,22 @@
+package com.example.spotifyweb.api.playlist.dto;
+
+import com.example.spotifyweb.api.playlist.domain.Playlist;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+public class PlaylistInfo {
+    private final String playlistTitle;
+    private final int followers;
+
+    public static PlaylistInfo of(final Playlist playlist) {
+        return PlaylistInfo.builder()
+                .playlistTitle(playlist.getPlaylistTitle())
+                .followers(playlist.getFollowers())
+                .build();
+    }
+}

--- a/spotify-web/src/main/java/com/example/spotifyweb/api/playlist/repository/PlaylistRepository.java
+++ b/spotify-web/src/main/java/com/example/spotifyweb/api/playlist/repository/PlaylistRepository.java
@@ -1,0 +1,7 @@
+package com.example.spotifyweb.api.playlist.repository;
+
+import com.example.spotifyweb.api.playlist.domain.Playlist;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PlaylistRepository extends JpaRepository<Playlist, Long> {
+}

--- a/spotify-web/src/main/java/com/example/spotifyweb/global/common/response/ErrorMessage.java
+++ b/spotify-web/src/main/java/com/example/spotifyweb/global/common/response/ErrorMessage.java
@@ -12,7 +12,7 @@ public enum ErrorMessage {
     STATION_NOT_FOUND_BY_ID_EXCEPTION(HttpStatus.NOT_FOUND.value(), "ID에 해당하는 스테이션이 존재하지 않습니다."),
     MEMBER_NOT_FOUND_BY_ID_EXCEPTION(HttpStatus.NOT_FOUND.value(), "ID에 해당하는 멤버가 존재하지 않습니다."),
     STATION_LIKING_BY_MEMBER_AND_STATION_EXCEPTION(HttpStatus.NOT_FOUND.value(), "멤버와 스테이션에 해당하는 좋아요가 존재하지 않습니다."),
-
+    FILTER_NOT_FOUND_BY_ID_EXCEPTION(HttpStatus.NOT_FOUND.value(), "ID에 해당하는 필터가 없습니다."),
     //400
     DUPLICATION_STATION_LIKE(HttpStatus.BAD_REQUEST.value(), "해당하는 회원이 이미 좋아요를 한 스테이션입니다.");
 

--- a/spotify-web/src/main/java/com/example/spotifyweb/global/common/response/SuccessMessage.java
+++ b/spotify-web/src/main/java/com/example/spotifyweb/global/common/response/SuccessMessage.java
@@ -12,6 +12,7 @@ public enum SuccessMessage {
     GET_STATIONS_SUCCESS(HttpStatus.OK.value(), "스테이션 제목 조회 성공"),
     GET_MUSICS_SUCCESS(HttpStatus.OK.value(), "스테이션에 따른 노래 리스트 조회 성공"),
     DELETE_STATION_LIKING_SUCCESS(HttpStatus.OK.value(), "스테이션 좋아요 취소 성공"),
+    GET_MUSICS_BY_GENRE_AND_FILTER_SUCCESS(HttpStatus.OK.value(), "장르와 필터에 다른 노래 리스트 조회 성공"),
 
     //201
     POST_STATION_LIKING_SUCCESS(HttpStatus.CREATED.value(), "스테이션 좋아요 성공")


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #15 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
장르에 따른 음악 필터링 조회 API를 구현했습니다.
플레이리스트도 함께 보내주기로 해서 플레이리스트 엔티티를 구현했습니다.
노래 장르를 pop, philipinepop, latinpop으로 변경했습니다.
한 응답안에 플레이리스트와 노래를 담아주어야해서 각각 playlistInfo와 musicInfo로 감싸주었습니다.
필터 아이디를 받아와서 해당 필터의 시작일과 끝나는 날을 받아 jpql을 사용하기 위해 [@Query](https://velog.io/@codren/Query-%EC%96%B4%EB%85%B8%ED%85%8C%EC%9D%B4%EC%85%98)를 사용해 구현했습니다.

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
감싸주는거 오랜만에 하니까 복잡하네여.. 

## 📬 Postman
<!-- postman 스크린샷을 첨부해주세요 -->
- 구현
![image](https://github.com/NOW-SOPT-CDSP-8/Spotify-BE/assets/128011308/15d07b69-09ca-42e6-9686-f643f306de84)
- 예외처리
![image](https://github.com/NOW-SOPT-CDSP-8/Spotify-BE/assets/128011308/e4292390-ef25-4aec-b05c-802e0c34e461)
