### PR TITLE
[fix] 스테이션에 따른 노래 목록 조회 API 수정 #18

### DIFF
--- a/spotify-web/src/main/java/com/example/spotifyweb/api/stationMusic/StationMusicRepository.java
+++ b/spotify-web/src/main/java/com/example/spotifyweb/api/stationMusic/StationMusicRepository.java
@@ -7,5 +7,5 @@ public interface StationMusicRepository extends JpaRepository<StationMusic, Long
 
     List<StationMusic> findFirst5ByStationIdOrderByIdAsc(Long stationId);
 
-    List<StationMusic> findTop5ByStationIdAndIdGreaterThanOrderByIdAsc(Long stationId, Long cursor);
+    List<StationMusic> findTop5ByStationIdAndMusicIdGreaterThanOrderByIdAsc(Long stationId, Long cursor);
 }

--- a/spotify-web/src/main/java/com/example/spotifyweb/api/stationMusic/StationMusicService.java
+++ b/spotify-web/src/main/java/com/example/spotifyweb/api/stationMusic/StationMusicService.java
@@ -31,7 +31,8 @@ public class StationMusicService {
             stationMusics = stationMusicRepository.findFirst5ByStationIdOrderByIdAsc(stationId);
         } else {
             // 특정 stationId에 해당하는 StationMusic을 PK기준으로 오름차순 정렬하고, PK > cursor 인 최대 5개의 결과를 반환합니다.
-            stationMusics = stationMusicRepository.findTop5ByStationIdAndIdGreaterThanOrderByIdAsc(stationId, cursor);
+            stationMusics = stationMusicRepository.findTop5ByStationIdAndMusicIdGreaterThanOrderByIdAsc(stationId,
+                    cursor);
         }
 
         return stationMusics.stream().map(stationMusic -> MusicGetResponseDto.of(stationMusic.getMusic()))


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #18 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->


## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->

findTop5ByStationIdAnd**Id**GreaterThanOrderByIdAsc 를 findTop5ByStationIdAnd**MusicId**GreaterThanOrderByIdAsc 로 수정했습니다.

findTop5ByStationIdAnd**Id**GreaterThanOrderByIdAsc 의 역할은 다음과 같습니다.
- findTop5By: 최대 5개의 레코드를 조회합니다.
- StationIdAndMusicIdGreaterThan: stationId가 특정 값과 일치하고 **Id가 cursor 값보다 큰 레코드를 필터링**합니다. ->_Id 가 아니라 musicId 가 cursor 보다 큰 값으로 필터링 해야함_
- OrderByIdAsc: id 필드를 기준으로 오름차순으로 정렬합니다.
- 
ffindTop5ByStationIdAnd**MusicId**GreaterThanOrderByIdAscd 의 역할은 다음과 같습니다.
- findTop5By: 최대 5개의 레코드를 조회합니다.
- StationIdAndMusicIdGreaterThan: stationId가 특정 값과 일치하고 **musicId가 cosor 값보다 큰 레코드를 필터링**합니다.
- OrderByIdAsc: id 필드를 기준으로 오름차순으로 정렬합니다.

commit message 를 실수로 [feat] 라고 적었습니다.
앞으로 주의 하도록 하겠습니다!




